### PR TITLE
Remove `masterUserPasswordSecretRef` as a required attribute

### DIFF
--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -1090,7 +1090,6 @@ spec:
                     type: array
                 required:
                 - engine
-                - masterUserPasswordSecretRef
                 - region
                 type: object
               providerConfigRef:


### PR DESCRIPTION
Fixes #1668

When creating an Aurora Global cluster with more than 2 regional clusters, the password attribute is mandatory for the first one, but not for the second one. Right now, it's impossible to create global cluster with more than 2 regional cluster.

If you avoid setting up the `masterUserPasswordSecretRef`, Crossplane CRD will complain because this field is required and won't let you create the resource.

If you set up the `masterUserPasswordSecretRef`, the AWS API will complain that the cluster can't be created with the following error message
```
create failed: cannot create DBCluster in AWS: InvalidParameterCombination: Cannot specify password for cross region replication cluster
```
